### PR TITLE
Attempt to fix mixed content

### DIFF
--- a/index.md
+++ b/index.md
@@ -3,7 +3,7 @@ layout: default
 ---
 
 <div id="app" class="d-none d-md-block">
-    <iframe src="app"></iframe>
+    <iframe src="/app/"></iframe>
 </div>
 
 


### PR DESCRIPTION
Currently the iframe does not load because of a mixed content violation (requesting unsecured content from a secured site). According to Firefox' network log, the following happens:
- Firefox tries to retreive "/app" from the **https** site:  
  ```
  GET /app HTTP/1.1
  ...
  Referer: https://taletime.github.io/
  ```
- GitHub pages returns a (faulty!) redirect to the **non-https** site:  
  ```
  HTTP/2.0 301 Moved Permanently
  ...
  location: http://taletime.github.io/app/
  ```

Firefox does not attempt to change the protocol of that redirect and simply stops there. I assume the faulty redirect could be avoided by appending the trailing slash, which is what this PR does.